### PR TITLE
Support for Dropwizard 0.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>0.8.0</dropwizard.version>
+        <dropwizard.version>0.9.0-rc4</dropwizard.version>
         <flyway.version>3.1</flyway.version>
     </properties>
 

--- a/src/main/java/io/dropwizard/flyway/cli/AbstractFlywayCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/AbstractFlywayCommand.java
@@ -4,7 +4,7 @@ import io.dropwizard.flyway.FlywayConfiguration;
 import io.dropwizard.flyway.FlywayFactory;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.ConfiguredCommand;
-import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.db.DatabaseConfiguration;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -37,7 +37,7 @@ abstract class AbstractFlywayCommand<T extends Configuration> extends Configured
 
     @Override
     protected void run(final Bootstrap<T> bootstrap, final Namespace namespace, final T configuration) throws Exception {
-        final DataSourceFactory datasourceFactory = databaseConfiguration.getDataSourceFactory(configuration);
+        final PooledDataSourceFactory datasourceFactory = databaseConfiguration.getDataSourceFactory(configuration);
         final FlywayFactory flywayFactory = flywayConfiguration.getFlywayFactory(configuration);
         final Flyway flyway = flywayFactory.build(datasourceFactory.build(bootstrap.getMetricRegistry(), "Flyway"));
 


### PR DESCRIPTION
Dropwizard 0.9.0 added support for alternative data source factories. 

`DatabaseConfiguration` now returns `PooledDataSourceFactory` interface, and it breaks compatibility with the current version of `dropwizard-flyway`, which expects `DataSourceFactory`.