### PR TITLE
Add name() to FlywayBundle.  

### DIFF
--- a/src/main/java/io/dropwizard/flyway/FlywayBundle.java
+++ b/src/main/java/io/dropwizard/flyway/FlywayBundle.java
@@ -27,7 +27,7 @@ public abstract class FlywayBundle<T extends Configuration>
         return new FlywayFactory();
     }
 
-    public String name() {
+    protected String name() {
         return "db";
     }
 }

--- a/src/main/java/io/dropwizard/flyway/FlywayBundle.java
+++ b/src/main/java/io/dropwizard/flyway/FlywayBundle.java
@@ -13,7 +13,7 @@ public abstract class FlywayBundle<T extends Configuration>
     @Override
     public final void initialize(final Bootstrap<?> bootstrap) {
         final Class<T> klass = Generics.getTypeParameter(getClass(), Configuration.class);
-        bootstrap.addCommand(new DbCommand<T>(this, this, klass));
+        bootstrap.addCommand(new DbCommand<T>(name(), this, this, klass));
     }
 
     @Override
@@ -25,5 +25,9 @@ public abstract class FlywayBundle<T extends Configuration>
     public FlywayFactory getFlywayFactory(T configuration) {
         // Default Flyway configuration
         return new FlywayFactory();
+    }
+
+    public String name() {
+        return "db";
     }
 }

--- a/src/main/java/io/dropwizard/flyway/cli/DbCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbCommand.java
@@ -14,10 +14,10 @@ public class DbCommand<T extends Configuration> extends AbstractFlywayCommand<T>
     private static final String COMMAND_NAME_ATTR = "subCommand";
     private final SortedMap<String, AbstractFlywayCommand<T>> subCommands = new TreeMap<>();
 
-    public DbCommand(final DatabaseConfiguration<T> databaseConfiguration,
+    public DbCommand(final String name, final DatabaseConfiguration<T> databaseConfiguration,
                      final FlywayConfiguration<T> flywayConfiguration,
                      final Class<T> configurationClass) {
-        super("db", "Run database migration tasks",
+        super(name, "Run database migration tasks",
                 databaseConfiguration, flywayConfiguration, configurationClass);
 
         addSubCommand(new DbMigrateCommand<>(databaseConfiguration, flywayConfiguration, configurationClass));


### PR DESCRIPTION
Allows for flyway migrations against separate databases.  Similar to the pattern used by dropwizard-migrations.