### PR TITLE
getting prepared for Flyway 6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <dropwizard.version>1.3.0</dropwizard.version>
-        <flyway.version>5.1.4</flyway.version>
+        <flyway.version>5.2.4</flyway.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/io/dropwizard/flyway/FlywayFactory.java
+++ b/src/main/java/io/dropwizard/flyway/FlywayFactory.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.callback.Callback;
-import org.flywaydb.core.api.errorhandler.ErrorHandler;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -634,63 +634,61 @@ public class FlywayFactory {
 
     public Flyway build(final DataSource dataSource) {
         final String[] emptyStringArray = new String[0];
-        final Flyway flyway = classLoader == null ? new Flyway() : new Flyway(classLoader);
+        
+        FluentConfiguration flyway = classLoader == null ? Flyway.configure() : Flyway.configure(classLoader);
 
-        flyway.setDataSource(dataSource);
-        flyway.setBaselineDescription(baselineDescription);
-        flyway.setBaselineOnMigrate(baselineOnMigrate);
-        flyway.setBaselineVersionAsString(baseLineVersion);
-        flyway.setCallbacksAsClassNames(callbacks.toArray(emptyStringArray));
-        flyway.setCleanDisabled(cleanDisabled);
-        flyway.setEncoding(encoding);
-        flyway.setGroup(group);
-        flyway.setIgnoreFutureMigrations(ignoreFutureMigrations);
-        flyway.setIgnoreIgnoredMigrations(ignoreIgnoredMigrations);
-        flyway.setIgnoreMissingMigrations(ignoreMissingMigrations);
-        flyway.setInstalledBy(installedBy);
-        flyway.setLocations(locations.toArray(emptyStringArray));
-        flyway.setMixed(mixed);
-        flyway.setOutOfOrder(outOfOrder);
-        flyway.setPlaceholderPrefix(placeholderPrefix);
-        flyway.setPlaceholderReplacement(placeholderReplacement);
-        flyway.setPlaceholderSuffix(placeholderSuffix);
-        flyway.setPlaceholders(placeholders);
-        flyway.setResolversAsClassNames(resolvers.toArray(emptyStringArray));
-        flyway.setSchemas(schemas.toArray(emptyStringArray));
-        flyway.setSkipDefaultCallbacks(skipDefaultCallbacks);
-        flyway.setSkipDefaultResolvers(skipDefaultResolvers);
-        flyway.setSqlMigrationPrefix(sqlMigrationPrefix);
-        flyway.setSqlMigrationSeparator(sqlMigrationSeparator);
-        flyway.setSqlMigrationSuffixes(sqlMigrationSuffixes.toArray(emptyStringArray));
-        flyway.setTable(metaDataTableName);
-        flyway.setValidateOnMigrate(validateOnMigrate);
+        flyway = flyway.dataSource(dataSource)
+              .baselineDescription(baselineDescription)
+              .baselineOnMigrate(baselineOnMigrate)
+              .baselineVersion(baseLineVersion)
+              .callbacks(callbacks.toArray(emptyStringArray))
+              .cleanDisabled(cleanDisabled)
+              .encoding(encoding)
+              .group(group)
+              .ignoreFutureMigrations(ignoreFutureMigrations)
+              .ignoreIgnoredMigrations(ignoreIgnoredMigrations)
+              .ignoreMissingMigrations(ignoreMissingMigrations)
+              .installedBy(installedBy)
+              .locations(locations.toArray(emptyStringArray))
+              .mixed(mixed)
+              .outOfOrder(outOfOrder)
+              .placeholderPrefix(placeholderPrefix)
+              .placeholderReplacement(placeholderReplacement)
+              .placeholderSuffix(placeholderSuffix)
+              .placeholders(placeholders)
+              .resolvers(resolvers.toArray(emptyStringArray))
+              .schemas(schemas.toArray(emptyStringArray))
+              .skipDefaultCallbacks(skipDefaultCallbacks)
+              .skipDefaultResolvers(skipDefaultResolvers)
+              .sqlMigrationPrefix(sqlMigrationPrefix)
+              .sqlMigrationSeparator(sqlMigrationSeparator)
+              .sqlMigrationSuffixes(sqlMigrationSuffixes.toArray(emptyStringArray))
+              .table(metaDataTableName)
+              .validateOnMigrate(validateOnMigrate);
 
         // Commercial features
         if (batch != null) {
-            flyway.setBatch(batch);
+            flyway.batch(batch);
         }
         if (dryRunOutputFile != null) {
-            flyway.setDryRunOutputAsFile(dryRunOutputFile);
-        }
-        if (errorHandlers != null) {
-            flyway.setErrorHandlersAsClassNames(errorHandlers.toArray(emptyStringArray));
+            flyway.dryRunOutput(dryRunOutputFile);
         }
         if (errorOverrides != null) {
-            flyway.setErrorOverrides(errorOverrides.toArray(emptyStringArray));
+            flyway.errorOverrides(errorOverrides.toArray(emptyStringArray));
         }
         if (oracleSqlPlus != null) {
-            flyway.setOracleSqlplus(oracleSqlPlus);
+            flyway.oracleSqlplus(oracleSqlPlus);
         }
         if (stream != null) {
-            flyway.setStream(stream);
+            flyway.stream(stream);
         }
         if (target != null) {
-            flyway.setTargetAsString(target);
+            flyway.target(target);
         }
         if (undoSqlMigrationPrefix != null) {
-            flyway.setUndoSqlMigrationPrefix(undoSqlMigrationPrefix);
+            flyway.undoSqlMigrationPrefix(undoSqlMigrationPrefix);
         }
 
-        return flyway;
+        return flyway.load();
     }
 }

--- a/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
@@ -6,6 +6,7 @@ import io.dropwizard.flyway.FlywayConfiguration;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,23 +70,27 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractFlywayCom
         final Boolean cleanOnValidationError = namespace.getBoolean(CLEAN_ON_VALIDATION_ERROR);
         final Boolean baselineOnMigrate = namespace.getBoolean(INIT_ON_MIGRATE);
 
+        FluentConfiguration config = Flyway.configure(flyway.getConfiguration().getClassLoader()).configuration(flyway.getConfiguration());
+        
         if (outOfOrder != null) {
-            flyway.setOutOfOrder(outOfOrder);
+            config.outOfOrder(outOfOrder);
         }
 
         if (validateOnMigrate != null) {
-            flyway.setValidateOnMigrate(validateOnMigrate);
+            config.validateOnMigrate(validateOnMigrate);
         }
 
         if (cleanOnValidationError != null) {
-            flyway.setCleanOnValidationError(cleanOnValidationError);
+            config.cleanOnValidationError(cleanOnValidationError);
         }
 
         if (baselineOnMigrate != null) {
-            flyway.setBaselineOnMigrate(baselineOnMigrate);
+            config.baselineOnMigrate(baselineOnMigrate);
         }
 
-        final int successfulMigrations = flyway.migrate();
+        Flyway customFlyway = config.load();
+        
+        final int successfulMigrations = customFlyway.migrate();
         LOG.debug("{} successful migrations applied", successfulMigrations);
     }
 }

--- a/src/main/java/io/dropwizard/flyway/cli/DbValidateCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbValidateCommand.java
@@ -6,6 +6,7 @@ import io.dropwizard.flyway.FlywayConfiguration;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
@@ -46,14 +47,18 @@ public class DbValidateCommand<T extends Configuration> extends AbstractFlywayCo
         final Boolean namespaceBoolean = namespace.getBoolean(OUT_OF_ORDER);
         final Boolean cleanOnValidationError = namespace.getBoolean(CLEAN_ON_VALIDATION_ERROR);
 
+        FluentConfiguration config = Flyway.configure(flyway.getConfiguration().getClassLoader()).configuration(flyway.getConfiguration());
+        
         if (namespaceBoolean != null) {
-            flyway.setOutOfOrder(namespaceBoolean);
+            config.outOfOrder(namespaceBoolean);
         }
 
         if (cleanOnValidationError != null) {
-            flyway.setCleanOnValidationError(cleanOnValidationError);
+            config.cleanOnValidationError(cleanOnValidationError);
         }
 
-        flyway.validate();
+        Flyway customFlyway = config.load();
+        
+        customFlyway.validate();
     }
 }

--- a/src/test/java/io/dropwizard/flyway/FlywayFactoryTest.java
+++ b/src/test/java/io/dropwizard/flyway/FlywayFactoryTest.java
@@ -27,9 +27,9 @@ public class FlywayFactoryTest {
         final Flyway flyway = factory.build(mockDataSource);
 
         assertNotNull(flyway);
-        assertSame(mockDataSource, flyway.getDataSource());
-        assertEquals(StandardCharsets.UTF_8, flyway.getEncoding());
-        assertEquals("flyway_schema_history", flyway.getTable());
-        assertEquals(0, flyway.getSchemas().length);
+        assertSame(mockDataSource, flyway.getConfiguration().getDataSource());
+        assertEquals(StandardCharsets.UTF_8, flyway.getConfiguration().getEncoding());
+        assertEquals("flyway_schema_history", flyway.getConfiguration().getTable());
+        assertEquals(0, flyway.getConfiguration().getSchemas().length);
     }
 }


### PR DESCRIPTION
In Flyway 5.2.4, the configuration system was revamped and
the old one was deprecated and replaced by a fluent interface.
The old one will disappear in Flyway 6.0.

Error handler configuration was removed because we were initializing
it to an array of an empty string. If this had any meaning in the
old Flyway API, an alternative will have to be found using Callbacks.