### PR TITLE
Add defaultSchema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Additionally you can override the following configuration settings of Flyway usi
     flyway:
       # The encoding of SQL migrations. (default: UTF-8) 
       encoding: UTF-8
+
+      # The default schema managed by Flyway. (default: the first schema listed in schemas)
+      defaultSchema:
       
       # The schemas managed by Flyway. (default: default schema of the connection)
       schemas:

--- a/src/main/java/io/dropwizard/flyway/FlywayFactory.java
+++ b/src/main/java/io/dropwizard/flyway/FlywayFactory.java
@@ -21,6 +21,8 @@ public class FlywayFactory {
     @NotEmpty
     private String encoding = StandardCharsets.UTF_8.name();
     @JsonProperty
+    private String defaultSchema = null;
+    @JsonProperty
     @NotNull
     private List<String> schemas = Collections.emptyList();
     @JsonProperty
@@ -126,6 +128,20 @@ public class FlywayFactory {
      */
     public void setEncoding(final String encoding) {
         this.encoding = encoding;
+    }
+
+    /**
+     * @see FluentConfiguration#getDefaultSchema()
+     */
+    public String getDefaultSchema() {
+        return defaultSchema;
+    }
+
+    /**
+     * @see FluentConfiguration#defaultSchema(String)
+     */
+    public void setDefaultSchema(final String defaultSchema) {
+        this.defaultSchema = defaultSchema;
     }
 
     /**
@@ -643,6 +659,7 @@ public class FlywayFactory {
               .baselineVersion(baseLineVersion)
               .callbacks(callbacks.toArray(emptyStringArray))
               .cleanDisabled(cleanDisabled)
+              .defaultSchema(defaultSchema)
               .encoding(encoding)
               .group(group)
               .ignoreFutureMigrations(ignoreFutureMigrations)

--- a/src/main/java/io/dropwizard/flyway/FlywayFactory.java
+++ b/src/main/java/io/dropwizard/flyway/FlywayFactory.java
@@ -21,6 +21,7 @@ public class FlywayFactory {
     @NotEmpty
     private String encoding = StandardCharsets.UTF_8.name();
     @JsonProperty
+    @Nullable
     private String defaultSchema = null;
     @JsonProperty
     @NotNull
@@ -133,6 +134,7 @@ public class FlywayFactory {
     /**
      * @see FluentConfiguration#getDefaultSchema()
      */
+    @Nullable
     public String getDefaultSchema() {
         return defaultSchema;
     }
@@ -140,7 +142,7 @@ public class FlywayFactory {
     /**
      * @see FluentConfiguration#defaultSchema(String)
      */
-    public void setDefaultSchema(final String defaultSchema) {
+    public void setDefaultSchema(@Nullable final String defaultSchema) {
         this.defaultSchema = defaultSchema;
     }
 
@@ -659,7 +661,6 @@ public class FlywayFactory {
               .baselineVersion(baseLineVersion)
               .callbacks(callbacks.toArray(emptyStringArray))
               .cleanDisabled(cleanDisabled)
-              .defaultSchema(defaultSchema)
               .encoding(encoding)
               .group(group)
               .ignoreFutureMigrations(ignoreFutureMigrations)
@@ -683,6 +684,10 @@ public class FlywayFactory {
               .sqlMigrationSuffixes(sqlMigrationSuffixes.toArray(emptyStringArray))
               .table(metaDataTableName)
               .validateOnMigrate(validateOnMigrate);
+
+        if (defaultSchema != null) {
+            flyway.defaultSchema(defaultSchema);
+        }
 
         // Commercial features
         if (batch != null) {


### PR DESCRIPTION
Add support for the optional `defaultSchema` property.  It allows setting the default schema for Flyway to manage.  Flyway's documentation of it can be found [here](https://flywaydb.org/documentation/commandline/migrate#defaultSchema) with the Javadoc for `FluentConfiguration#defaultSchema` [here](https://flywaydb.org/documentation/api/javadoc/org/flywaydb/core/api/configuration/FluentConfiguration.html#defaultSchema(java.lang.String)).
@joschi , once this is merged, would you mind doing a backport to the `1.3.x` branch and then releasing a point release from the `1.3.x` branch including it?  I haven't yet migrated some of my services to Dropwizard 2.  I can put up the appropriate PR for the backport if you want once this is merged.  Thanks!