### PR TITLE
Use correct argument types for subparser

### DIFF
--- a/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
@@ -33,17 +33,20 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractFlywayCom
 
         subparser.addArgument("--" + OUT_OF_ORDER)
                 .dest(OUT_OF_ORDER)
+                .type(Boolean.class)
                 .help("Allows migrations to be run \"out of order\". " +
                         "If you already have versions 1 and 3 applied, and now a version 2 is found, it will be applied too instead of being ignored.");
 
         subparser.addArgument("--" + VALIDATE_ON_MIGRATE)
                 .dest(VALIDATE_ON_MIGRATE)
+                .type(Boolean.class)
                 .help("Whether to automatically call validate or not when running migrate. " +
                         "For each sql migration a CRC32 checksum is calculated when the sql script is executed. " +
                         "The validate mechanism checks if the sql migration in the classpath still has the same checksum as the sql migration already executed in the database.");
 
         subparser.addArgument("--" + CLEAN_ON_VALIDATION_ERROR)
                 .dest(CLEAN_ON_VALIDATION_ERROR)
+                .type(Boolean.class)
                 .help("Whether to automatically call clean or not when a validation error occurs. " +
                         "This is exclusively intended as a convenience for development. " +
                         "Even tough we strongly recommend not to change migration scripts once they have been checked into SCM and run, this provides a way of dealing with this case in a smooth manner. " +
@@ -52,6 +55,7 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractFlywayCom
 
         subparser.addArgument("--" + INIT_ON_MIGRATE)
                 .dest(INIT_ON_MIGRATE)
+                .type(Boolean.class)
                 .help("Whether to automatically call init when migrate is executed against a non-empty schema with no metadata table. " +
                         "This schema will then be initialized with the initVersion before executing the migrations. " +
                         "Only migrations above initVersion will then be applied. " +

--- a/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
@@ -33,20 +33,20 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractFlywayCom
 
         subparser.addArgument("--" + OUT_OF_ORDER)
                 .dest(OUT_OF_ORDER)
-                .type(Boolean.class)
+                .storeConst(Boolean.TRUE)
                 .help("Allows migrations to be run \"out of order\". " +
                         "If you already have versions 1 and 3 applied, and now a version 2 is found, it will be applied too instead of being ignored.");
 
         subparser.addArgument("--" + VALIDATE_ON_MIGRATE)
                 .dest(VALIDATE_ON_MIGRATE)
-                .type(Boolean.class)
+                .storeConst(Boolean.TRUE)
                 .help("Whether to automatically call validate or not when running migrate. " +
                         "For each sql migration a CRC32 checksum is calculated when the sql script is executed. " +
                         "The validate mechanism checks if the sql migration in the classpath still has the same checksum as the sql migration already executed in the database.");
 
         subparser.addArgument("--" + CLEAN_ON_VALIDATION_ERROR)
                 .dest(CLEAN_ON_VALIDATION_ERROR)
-                .type(Boolean.class)
+                .storeConst(Boolean.TRUE)
                 .help("Whether to automatically call clean or not when a validation error occurs. " +
                         "This is exclusively intended as a convenience for development. " +
                         "Even tough we strongly recommend not to change migration scripts once they have been checked into SCM and run, this provides a way of dealing with this case in a smooth manner. " +
@@ -55,7 +55,7 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractFlywayCom
 
         subparser.addArgument("--" + INIT_ON_MIGRATE)
                 .dest(INIT_ON_MIGRATE)
-                .type(Boolean.class)
+                .storeConst(Boolean.TRUE)
                 .help("Whether to automatically call init when migrate is executed against a non-empty schema with no metadata table. " +
                         "This schema will then be initialized with the initVersion before executing the migrations. " +
                         "Only migrations above initVersion will then be applied. " +


### PR DESCRIPTION
Currently all those arguments do not work. Running a command like this: ` java -jar application.jar db migrate --initOnMigrate true config.yml ` results in the following exception:

`java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Boolean (java.lang.String and java.lang.Boolean are in module java.base of loader 'bootstrap')
        at net.sourceforge.argparse4j.inf.Namespace.getBoolean(Namespace.java:174)
        at io.dropwizard.flyway.cli.DbMigrateCommand.run(DbMigrateCommand.java:67)
        at io.dropwizard.flyway.cli.DbCommand.run(DbCommand.java:48)
`

This makes it again possible to use --initOnMigrate without argument, but doesn't set a default value if it is not used (null instead)
