### PR TITLE
Use storeConst to allow to use options without arguments again

### DIFF
--- a/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
@@ -5,6 +5,7 @@ import io.dropwizard.db.DatabaseConfiguration;
 import io.dropwizard.flyway.FlywayConfiguration;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.impl.Arguments;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.slf4j.Logger;
@@ -33,17 +34,20 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractFlywayCom
 
         subparser.addArgument("--" + OUT_OF_ORDER)
                 .dest(OUT_OF_ORDER)
+                .action(Arguments.storeConst()).setConst(Boolean.TRUE)
                 .help("Allows migrations to be run \"out of order\". " +
                         "If you already have versions 1 and 3 applied, and now a version 2 is found, it will be applied too instead of being ignored.");
 
         subparser.addArgument("--" + VALIDATE_ON_MIGRATE)
                 .dest(VALIDATE_ON_MIGRATE)
+                .action(Arguments.storeConst()).setConst(Boolean.TRUE)
                 .help("Whether to automatically call validate or not when running migrate. " +
                         "For each sql migration a CRC32 checksum is calculated when the sql script is executed. " +
                         "The validate mechanism checks if the sql migration in the classpath still has the same checksum as the sql migration already executed in the database.");
 
         subparser.addArgument("--" + CLEAN_ON_VALIDATION_ERROR)
                 .dest(CLEAN_ON_VALIDATION_ERROR)
+                .action(Arguments.storeConst()).setConst(Boolean.TRUE)
                 .help("Whether to automatically call clean or not when a validation error occurs. " +
                         "This is exclusively intended as a convenience for development. " +
                         "Even tough we strongly recommend not to change migration scripts once they have been checked into SCM and run, this provides a way of dealing with this case in a smooth manner. " +
@@ -52,6 +56,7 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractFlywayCom
 
         subparser.addArgument("--" + INIT_ON_MIGRATE)
                 .dest(INIT_ON_MIGRATE)
+                .action(Arguments.storeConst()).setConst(Boolean.TRUE)
                 .help("Whether to automatically call init when migrate is executed against a non-empty schema with no metadata table. " +
                         "This schema will then be initialized with the initVersion before executing the migrations. " +
                         "Only migrations above initVersion will then be applied. " +


### PR DESCRIPTION
Currently all those arguments do not work, since they now require an argument but running a command like this: `java -jar application.jar db migrate --initOnMigrate true config.yml` results in the following exception:

```
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Boolean java.lang.String and java.lang.Boolean are in module java.base of loader 'bootstrap')
 at net.sourceforge.argparse4j.inf.Namespace.getBoolean(Namespace.java:174)
 at io.dropwizard.flyway.cli.DbMigrateCommand.run(DbMigrateCommand.java:67)
 at io.dropwizard.flyway.cli.DbCommand.run(DbCommand.java:48)
```

This PR makes it again possible to use `--initOnMigrate` without argument, but doesn't set a default value if it is not used (`null` instead)

Refs #22
Refs #23