### PR TITLE
Fix arguments for db validate, add tests

### DIFF
--- a/src/main/java/io/dropwizard/flyway/FlywayFactory.java
+++ b/src/main/java/io/dropwizard/flyway/FlywayFactory.java
@@ -75,6 +75,8 @@ public class FlywayFactory {
     @JsonProperty
     private boolean cleanDisabled = false;
     @JsonProperty
+    private boolean cleanOnValidationError = false;
+    @JsonProperty
     private boolean group = false;
     @JsonProperty
     private boolean ignoreFutureMigrations = true;
@@ -413,6 +415,20 @@ public class FlywayFactory {
     }
 
     /**
+     * @see FluentConfiguration#isCleanOnValidationError() 
+     */
+    public boolean isCleanOnValidationError() {
+        return cleanOnValidationError;
+    }
+
+    /**
+     * @see FluentConfiguration#cleanOnValidationError(boolean) ()
+     */
+    public void setCleanOnValidationError(boolean cleanOnValidationError) {
+        this.cleanOnValidationError = cleanOnValidationError;
+    }
+
+    /**
      * @see FluentConfiguration#isGroup()
      */
     public boolean isGroup() {
@@ -661,6 +677,7 @@ public class FlywayFactory {
               .baselineVersion(baseLineVersion)
               .callbacks(callbacks.toArray(emptyStringArray))
               .cleanDisabled(cleanDisabled)
+              .cleanOnValidationError(cleanOnValidationError)
               .encoding(encoding)
               .group(group)
               .ignoreFutureMigrations(ignoreFutureMigrations)

--- a/src/main/java/io/dropwizard/flyway/cli/AbstractFlywayCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/AbstractFlywayCommand.java
@@ -39,6 +39,10 @@ abstract class AbstractFlywayCommand<T extends Configuration> extends Configured
     protected void run(final Bootstrap<T> bootstrap, final Namespace namespace, final T configuration) throws Exception {
         final PooledDataSourceFactory datasourceFactory = databaseConfiguration.getDataSourceFactory(configuration);
         final FlywayFactory flywayFactory = flywayConfiguration.getFlywayFactory(configuration);
+
+        // Give subclasses an option to set additional config flags for flyway.
+        setAdditionalOptions(flywayFactory, namespace);
+        
         final Flyway flyway = flywayFactory.build(datasourceFactory.build(bootstrap.getMetricRegistry(), "Flyway"));
 
         try {
@@ -48,6 +52,7 @@ abstract class AbstractFlywayCommand<T extends Configuration> extends Configured
             throw e;
         }
     }
-
+    
+    protected abstract void setAdditionalOptions(FlywayFactory flywayFactory, Namespace namespace);
     protected abstract void run(final Namespace namespace, final Flyway flyway) throws Exception;
 }

--- a/src/main/java/io/dropwizard/flyway/cli/DbCleanCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbCleanCommand.java
@@ -6,7 +6,7 @@ import io.dropwizard.db.DatabaseConfiguration;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.flywaydb.core.Flyway;
 
-public class DbCleanCommand<T extends Configuration> extends AbstractFlywayCommand<T> {
+public class DbCleanCommand<T extends Configuration> extends NoOptionsFlywayCommand<T> {
     public DbCleanCommand(final DatabaseConfiguration<T> databaseConfiguration,
                           final FlywayConfiguration<T> flywayConfiguration,
                           final Class<T> configurationClass) {

--- a/src/main/java/io/dropwizard/flyway/cli/DbCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbCommand.java
@@ -3,6 +3,7 @@ package io.dropwizard.flyway.cli;
 import io.dropwizard.flyway.FlywayConfiguration;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DatabaseConfiguration;
+import io.dropwizard.flyway.FlywayFactory;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import org.flywaydb.core.Flyway;
@@ -41,6 +42,11 @@ public class DbCommand<T extends Configuration> extends AbstractFlywayCommand<T>
                     .description(subCommand.getDescription());
             subCommand.configure(cmdParser);
         }
+    }
+
+    @Override
+    protected void setAdditionalOptions(FlywayFactory flywayFactory, Namespace namespace) {
+        subCommands.get(namespace.getString(COMMAND_NAME_ATTR)).setAdditionalOptions(flywayFactory, namespace);
     }
 
     @Override

--- a/src/main/java/io/dropwizard/flyway/cli/DbInfoCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbInfoCommand.java
@@ -8,7 +8,7 @@ import org.flywaydb.core.Flyway;
 
 import static org.flywaydb.core.internal.info.MigrationInfoDumper.dumpToAsciiTable;
 
-public class DbInfoCommand<T extends Configuration> extends AbstractFlywayCommand<T> {
+public class DbInfoCommand<T extends Configuration> extends NoOptionsFlywayCommand<T> {
     public DbInfoCommand(final DatabaseConfiguration<T> databaseConfiguration,
                          final FlywayConfiguration<T> flywayConfiguration,
                          final Class<T> configurationClass) {

--- a/src/main/java/io/dropwizard/flyway/cli/DbInitCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbInitCommand.java
@@ -6,7 +6,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.db.DatabaseConfiguration;
 import net.sourceforge.argparse4j.inf.Namespace;
 
-public class DbInitCommand<T extends Configuration> extends AbstractFlywayCommand<T> {
+public class DbInitCommand<T extends Configuration> extends NoOptionsFlywayCommand<T> {
     public DbInitCommand(final DatabaseConfiguration<T> databaseConfiguration,
                          final FlywayConfiguration<T> flywayConfiguration,
                          final Class<T> configurationClass) {

--- a/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbMigrateCommand.java
@@ -3,6 +3,7 @@ package io.dropwizard.flyway.cli;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DatabaseConfiguration;
 import io.dropwizard.flyway.FlywayConfiguration;
+import io.dropwizard.flyway.FlywayFactory;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.impl.Arguments;
@@ -65,33 +66,32 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractFlywayCom
     }
 
     @Override
-    public void run(final Namespace namespace, final Flyway flyway) throws Exception {
+    protected void setAdditionalOptions(FlywayFactory flywayFactory, Namespace namespace) {
         final Boolean outOfOrder = namespace.getBoolean(OUT_OF_ORDER);
         final Boolean validateOnMigrate = namespace.getBoolean(VALIDATE_ON_MIGRATE);
         final Boolean cleanOnValidationError = namespace.getBoolean(CLEAN_ON_VALIDATION_ERROR);
         final Boolean baselineOnMigrate = namespace.getBoolean(INIT_ON_MIGRATE);
 
-        FluentConfiguration config = Flyway.configure(flyway.getConfiguration().getClassLoader()).configuration(flyway.getConfiguration());
-        
         if (outOfOrder != null) {
-            config.outOfOrder(outOfOrder);
+            flywayFactory.setOutOfOrder(outOfOrder);
         }
 
         if (validateOnMigrate != null) {
-            config.validateOnMigrate(validateOnMigrate);
+            flywayFactory.setValidateOnMigrate(validateOnMigrate);
         }
 
         if (cleanOnValidationError != null) {
-            config.cleanOnValidationError(cleanOnValidationError);
+            flywayFactory.setCleanOnValidationError(cleanOnValidationError);
         }
 
         if (baselineOnMigrate != null) {
-            config.baselineOnMigrate(baselineOnMigrate);
+            flywayFactory.setBaselineOnMigrate(baselineOnMigrate);
         }
+    }
 
-        Flyway customFlyway = config.load();
-        
-        final int successfulMigrations = customFlyway.migrate();
+    @Override
+    public void run(final Namespace namespace, final Flyway flyway) throws Exception {
+        final int successfulMigrations = flyway.migrate();
         LOG.debug("{} successful migrations applied", successfulMigrations);
     }
 }

--- a/src/main/java/io/dropwizard/flyway/cli/DbRepairCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/DbRepairCommand.java
@@ -6,7 +6,7 @@ import io.dropwizard.db.DatabaseConfiguration;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.flywaydb.core.Flyway;
 
-public class DbRepairCommand<T extends Configuration> extends AbstractFlywayCommand<T> {
+public class DbRepairCommand<T extends Configuration> extends NoOptionsFlywayCommand<T> {
     public DbRepairCommand(final DatabaseConfiguration<T> databaseConfiguration,
                            final FlywayConfiguration<T> flywayConfiguration,
                            final Class<T> configurationClass) {

--- a/src/main/java/io/dropwizard/flyway/cli/NoOptionsFlywayCommand.java
+++ b/src/main/java/io/dropwizard/flyway/cli/NoOptionsFlywayCommand.java
@@ -1,0 +1,20 @@
+package io.dropwizard.flyway.cli;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.db.DatabaseConfiguration;
+import io.dropwizard.flyway.FlywayConfiguration;
+import io.dropwizard.flyway.FlywayFactory;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+public abstract class NoOptionsFlywayCommand<T extends Configuration> extends AbstractFlywayCommand<T> {
+
+    NoOptionsFlywayCommand(String name, String description, DatabaseConfiguration<T> databaseConfiguration,
+                           FlywayConfiguration<T> flywayConfiguration, Class<T> configurationClass) {
+        super(name, description, databaseConfiguration, flywayConfiguration, configurationClass);
+    }
+
+    @Override
+    protected void setAdditionalOptions(FlywayFactory flywayFactory, Namespace namespace) {
+        // Empty on purpose
+    }
+}

--- a/src/test/java/io/dropwizard/flyway/cli/AbstractCommandTest.java
+++ b/src/test/java/io/dropwizard/flyway/cli/AbstractCommandTest.java
@@ -1,0 +1,60 @@
+package io.dropwizard.flyway.cli;
+
+import java.util.Optional;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.cli.Cli;
+import io.dropwizard.db.DatabaseConfiguration;
+import io.dropwizard.db.PooledDataSourceFactory;
+import io.dropwizard.flyway.FlywayConfiguration;
+import io.dropwizard.flyway.FlywayFactory;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.JarLocation;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AbstractCommandTest {
+    protected Cli cli;
+
+    protected FlywayFactory mockFlywayFactory;
+    protected Flyway mockFlyway;
+
+    private static class TestApplication extends Application<TestConfiguration> {
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+        }
+    }
+
+    public static class TestConfiguration extends Configuration {
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Setup necessary mock
+        final JarLocation location = mock(JarLocation.class);
+        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+
+        final DatabaseConfiguration dbConfiguration = mock(DatabaseConfiguration.class);
+        when(dbConfiguration.getDataSourceFactory(any())).thenReturn(mock(PooledDataSourceFactory.class));
+
+        final FlywayConfiguration flywayConfiguration = mock(FlywayConfiguration.class);
+        mockFlywayFactory = mock(FlywayFactory.class);
+        when(flywayConfiguration.getFlywayFactory(any())).thenReturn(mockFlywayFactory);
+
+        mockFlyway = mock(Flyway.class);
+        when(mockFlywayFactory.build(any())).thenReturn(mockFlyway);
+
+        // Add commands you want to test
+        final Bootstrap<TestConfiguration> bootstrap = new Bootstrap<>(new TestApplication());
+        bootstrap.addCommand(new DbCommand<TestConfiguration>("db", dbConfiguration, flywayConfiguration, TestConfiguration.class));
+
+        // Build what'll run the command and interpret arguments
+        cli = new Cli(location, bootstrap, System.out, System.err);
+    }
+}

--- a/src/test/java/io/dropwizard/flyway/cli/DbMigrateCommandTest.java
+++ b/src/test/java/io/dropwizard/flyway/cli/DbMigrateCommandTest.java
@@ -1,0 +1,53 @@
+package io.dropwizard.flyway.cli;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class DbMigrateCommandTest extends AbstractCommandTest {
+
+    @Test
+    public void testDefaultArguments() {
+        cli.run("db", "migrate");
+
+        verify(mockFlywayFactory, never()).setBaselineOnMigrate(anyBoolean());
+        verify(mockFlywayFactory, never()).setOutOfOrder(anyBoolean());
+        verify(mockFlywayFactory, never()).setValidateOnMigrate(anyBoolean());
+        verify(mockFlywayFactory, never()).setCleanOnValidationError(anyBoolean());
+        verify(mockFlyway).migrate();
+    }
+
+    @Test
+    public void testInitOnMigrate() {
+        cli.run("db", "migrate", "--initOnMigrate");
+
+        verify(mockFlywayFactory).setBaselineOnMigrate(true);
+        verify(mockFlyway).migrate();
+    }
+
+    @Test
+    public void testValidateOMigrate() {
+        cli.run("db", "migrate", "--validateOnMigrate");
+
+        verify(mockFlywayFactory).setValidateOnMigrate(true);
+        verify(mockFlyway).migrate();
+    }
+
+    @Test
+    public void testOutOfOrder() {
+        cli.run("db", "migrate", "--outOfOrder");
+
+        verify(mockFlywayFactory).setOutOfOrder(true);
+        verify(mockFlyway).migrate();
+    }
+
+    @Test
+    public void testCleanOnValidationError() {
+        cli.run("db", "migrate", "--cleanOnValidationError");
+
+        verify(mockFlywayFactory).setCleanOnValidationError(true);
+        verify(mockFlyway).migrate();
+    }
+}

--- a/src/test/java/io/dropwizard/flyway/cli/DbValidateCommandTest.java
+++ b/src/test/java/io/dropwizard/flyway/cli/DbValidateCommandTest.java
@@ -1,0 +1,35 @@
+package io.dropwizard.flyway.cli;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class DbValidateCommandTest extends AbstractCommandTest {
+
+    @Test
+    public void testDefaultArguments() {
+        cli.run("db", "validate");
+
+        verify(mockFlywayFactory, never()).setOutOfOrder(anyBoolean());
+        verify(mockFlywayFactory, never()).setCleanOnValidationError(anyBoolean());
+        verify(mockFlyway).validate();
+    }
+
+    @Test
+    public void testOutOfOrder() {
+        cli.run("db", "validate", "--outOfOrder");
+
+        verify(mockFlywayFactory).setOutOfOrder(true);
+        verify(mockFlyway).validate();
+    }
+
+    @Test
+    public void testCleanOnValidationError() {
+        cli.run("db", "validate", "--cleanOnValidationError");
+
+        verify(mockFlywayFactory).setCleanOnValidationError(true);
+        verify(mockFlyway).validate();
+    }
+}


### PR DESCRIPTION
This fixes the same issue as https://github.com/dropwizard/dropwizard-flyway/pull/92 also for the DbValidateCommand.

I also included tests for those two commands, and some refactoring to make the DbCommands more testable.

Also, I have some doubts if the VALIDATE_ON_MIGRATE option actually makes sense the way it is implemented, since it sets an option to true that is already true by default. But I didnt want to change the behaviour there.