### PR TITLE
Add `ignorePendingMigrations` setting

### DIFF
--- a/src/main/java/io/dropwizard/flyway/FlywayFactory.java
+++ b/src/main/java/io/dropwizard/flyway/FlywayFactory.java
@@ -85,6 +85,8 @@ public class FlywayFactory {
     @JsonProperty
     private boolean ignoreMissingMigrations = false;
     @JsonProperty
+    private boolean ignorePendingMigrations = false;
+    @JsonProperty
     @NotNull
     private String installedBy = "";
     @JsonProperty
@@ -484,6 +486,21 @@ public class FlywayFactory {
         this.ignoreMissingMigrations = ignoreMissingMigrations;
     }
 
+
+    /**
+     * @see FluentConfiguration#ignorePendingMigrations(boolean)
+     */
+    public boolean isIgnorePendingMigrations() {
+        return ignorePendingMigrations;
+    }
+
+    /**
+     * @see FluentConfiguration#ignorePendingMigrations(boolean)
+     */
+    public void setIgnorePendingMigrations(boolean ignorePendingMigrations) {
+        this.ignorePendingMigrations = ignorePendingMigrations;
+    }
+
     /**
      * @see FluentConfiguration#getInstalledBy()
      */
@@ -683,6 +700,7 @@ public class FlywayFactory {
               .ignoreFutureMigrations(ignoreFutureMigrations)
               .ignoreIgnoredMigrations(ignoreIgnoredMigrations)
               .ignoreMissingMigrations(ignoreMissingMigrations)
+              .ignorePendingMigrations(ignorePendingMigrations)
               .installedBy(installedBy)
               .locations(locations.toArray(emptyStringArray))
               .mixed(mixed)


### PR DESCRIPTION
There seems to be a new setting in flyway, ignorePendingMigrations, that is not yet available in dropwizard-flyway. I don't know when exactly it was added, but it seems to be a reasonable addition.

In a project I am calling flyway.validate on startup, to basically prevent the app to start if a migration has not been applied yet. It prompts  `To fix this error, either run migrate, or set -ignorePendingMigrations=true.`

With this PR, you can supply this parameter in the config as well.